### PR TITLE
returnpath: not empty check vs trying to count non countable

### DIFF
--- a/class.returnpath.php
+++ b/class.returnpath.php
@@ -210,7 +210,7 @@ class ReturnPath
             }
             $parameters = $newParams;
         }
-        if (($httpMethod == 'GET') && ! is_null($parameters) && (count($parameters) > 0)) {
+        if (($httpMethod == 'GET') && ! is_null($parameters) && !empty($parameters)) {
             $url .= (($this->authenticationMethod == "private") ? '&' : '?') . $parameters;
         }
 


### PR DESCRIPTION
This check is better, and doesn't issue notice on PHP 7.2.

Please consider merging it in, and releasing minor version afterwards. Thank you!